### PR TITLE
Legacy probe

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -175,6 +175,7 @@ function createToolLengthSetRoutine(settings, toolOffsets = { x: 0, y: 0, z: 0 }
     ${auxOn}
     G43.1 Z0
     G38.2 G91 Z-${settings.seekDistance} F${settings.seekFeedrate}
+    G4 P0.2
     G38.4 G91 Z5 F${fineProbeFeedrate}
     G91 G0 Z5
     G90

--- a/commands.js
+++ b/commands.js
@@ -73,54 +73,60 @@ const sanitizeCoords = (coords = {}) => ({
   z: toFiniteNumber(coords.z)
 });
 
-const buildInitialConfig = (raw = {}) => ({
-  // Position Settings
-  pocket1: sanitizeCoords(raw.pocket1),
-  toolSetter: sanitizeCoords(raw.toolSetter),
-  parking: sanitizeCoords(raw.parking),
+const buildInitialConfig = (raw = {}) => {
+  
+  return {
+    // Position Settings
+    pocket1: sanitizeCoords(raw.pocket1),
+    toolSetter: sanitizeCoords(raw.toolSetter),
+    parking: sanitizeCoords(raw.parking),
 
-  // Tool Settings
-  numberOfTools: toFiniteNumber(raw.numberOfTools, 1),
+    // Tool Settings
+    numberOfTools: toFiniteNumber(raw.numberOfTools, 1),
 
-  // UI Toggle Settings
-  autoSwap: raw.autoSwap === true,
-  pauseBeforeUnload: raw.pauseBeforeUnload !== false,
-  showMacroCommand: raw.showMacroCommand ?? false,
-  performTlsAfterHome: raw.performTlsAfterHome ?? false,
-  waitForSpindle: raw.waitForSpindle !== false,
+    // UI Toggle Settings
+    autoSwap: raw.autoSwap === true,
+    pauseBeforeUnload: raw.pauseBeforeUnload !== false,
+    showMacroCommand: raw.showMacroCommand ?? false,
+    performTlsAfterHome: raw.performTlsAfterHome ?? false,
+    waitForSpindle: raw.waitForSpindle !== false,
 
-  // Advanced Settings (no UI, JSON only)
-  // Z-axis Settings
-  zEngagement: toFiniteNumber(raw.zEngagement, -50),
-  zSafe: toFiniteNumber(raw.zSafe, 0),
-  zSpinOff: toFiniteNumber(raw.zSpinOff, 23),
-  zRetreat: toFiniteNumber(raw.zRetreat, 12),
+    // Advanced Settings (no UI, JSON only)
+    // Z-axis Settings
+    zEngagement: toFiniteNumber(raw.zEngagement, -50),
+    zSafe: toFiniteNumber(raw.zSafe, 0),
+    zSpinOff: toFiniteNumber(raw.zSpinOff, 23),
+    zRetreat: toFiniteNumber(raw.zRetreat, 12),
 
-  // Tool Change Settings
-  unloadRpm: toFiniteNumber(raw.unloadRpm, 1500),
-  loadRpm: toFiniteNumber(raw.loadRpm, 1200),
-  engageFeedrate: toFiniteNumber(raw.engageFeedrate, 3500),
+    // Tool Change Settings
+    unloadRpm: toFiniteNumber(raw.unloadRpm, 1500),
+    loadRpm: toFiniteNumber(raw.loadRpm, 1200),
+    engageFeedrate: toFiniteNumber(raw.engageFeedrate, 3500),
 
-  // Tool Length Setter Settings
-  zProbeStart: toFiniteNumber(raw.zProbeStart, -10),
-  seekDistance: toFiniteNumber(raw.seekDistance, 50),
-  seekFeedrate: toFiniteNumber(raw.seekFeedrate, 100),
+    // Tool Length Setter Settings
+    zProbeStart: toFiniteNumber(raw.zProbeStart, -10),
+    seekDistance: toFiniteNumber(raw.seekDistance, 50),
+    seekFeedrate: toFiniteNumber(raw.seekFeedrate, 100),
 
-  // Aux Output Settings (-1 = disabled, 0+ = M64 P{n}, 'M7' or 'M8' for coolant)
-  tlsAuxOutput: raw.tlsAuxOutput === 'M7' || raw.tlsAuxOutput === 'M8'
-    ? raw.tlsAuxOutput
-    : toFiniteNumber(raw.tlsAuxOutput, -1),
+    // Aux Output Settings (-1 = disabled, 0+ = M64 P{n}, 'M7' or 'M8' for coolant)
+    tlsAuxOutput: raw.tlsAuxOutput === 'M7' || raw.tlsAuxOutput === 'M8'
+      ? raw.tlsAuxOutput
+      : toFiniteNumber(raw.tlsAuxOutput, -1),
 
-  // Probe Tool Settings
-  addProbe: raw.addProbe ?? false,
-  probeLoadGcode: raw.probeLoadGcode ?? '',
-  probeUnloadGcode: raw.probeUnloadGcode ?? '',
+    // Probe Tool Settings
+    addProbe: raw.addProbe ?? false,
+    probeLoadGcode: raw.probeLoadGcode ?? '',
+    probeUnloadGcode: raw.probeUnloadGcode ?? '',
+    legacyProbe: raw.legacyProbe ?? false,
+    secondSeekDistance: toFiniteNumber(raw.secondSeekDistance, 1),
+    secondSeekFeedrate: toFiniteNumber(raw.secondSeekFeedrate, 25),
 
-  // Tool Change Events
-  preToolChangeGcode: raw.preToolChangeGcode ?? '',
-  postToolChangeGcode: raw.postToolChangeGcode ?? '',
-  abortEventGcode: raw.abortEventGcode ?? ''
-});
+    // Tool Change Events
+    preToolChangeGcode: raw.preToolChangeGcode ?? '',
+    postToolChangeGcode: raw.postToolChangeGcode ?? '',
+    abortEventGcode: raw.abortEventGcode ?? ''
+  };
+};
 
 // === Tool Offset Lookup (pure, from pre-fetched array) ===
 
@@ -146,11 +152,12 @@ const formatGCode = (gcode) => {
 
 // === Routine Generators ===
 
-function createToolLengthSetRoutine(settings, toolOffsets = { x: 0, y: 0, z: 0 }) {
+function createToolLengthSetRoutine(settings, toolOffsets = { x: 0, y: 0, z: 0 }, toolNumber) {
   const tlsX = settings.toolSetter.x + (toolOffsets.x || 0);
   const tlsY = settings.toolSetter.y + (toolOffsets.y || 0);
   const tlsZ = toolOffsets.z || 0;
   const fineProbeFeedrate = settings.seekFeedrate < 75 ? settings.seekFeedrate : 75;
+  const legacyProbe = settings.legacyProbe;
 
   // Extra Z rapid move for shorter tools (z offset is typically negative)
   const extraZMove = tlsZ !== 0 ? `G91 G0 Z${tlsZ}\n    G90` : '';
@@ -167,6 +174,24 @@ function createToolLengthSetRoutine(settings, toolOffsets = { x: 0, y: 0, z: 0 }
     auxOff = `G4 P0\n    M65 P${auxOutput}\n    G4 P0`;
   }
 
+  let probeCommand = '';
+  if (legacyProbe && toolNumber === PROBE_TOOL_NUMBER) {
+    const secondSeekDistance = settings.secondSeekDistance || 1;
+    const secondSeekFeedrate = settings.secondSeekFeedrate || 25;
+   
+    probeCommand = `
+    G38.2 G91 Z-${settings.seekDistance} F${settings.seekFeedrate}
+    G4 P0.2
+    G0 G91 Z${secondSeekDistance}
+    G4 P0.2
+    G38.2 G91 Z-${secondSeekDistance} F${secondSeekFeedrate}`
+  } else {
+    probeCommand = `
+    G38.2 G91 Z-${settings.seekDistance} F${settings.seekFeedrate}
+    G4 P0.2
+    G38.4 G91 Z5 F${fineProbeFeedrate}`;
+  }
+
   return `
     G53 G0 Z${settings.zSafe}
     G53 G0 X${tlsX} Y${tlsY}
@@ -174,9 +199,7 @@ function createToolLengthSetRoutine(settings, toolOffsets = { x: 0, y: 0, z: 0 }
     ${extraZMove}
     ${auxOn}
     G43.1 Z0
-    G38.2 G91 Z-${settings.seekDistance} F${settings.seekFeedrate}
-    G4 P0.2
-    G38.4 G91 Z5 F${fineProbeFeedrate}
+    ${probeCommand}
     G91 G0 Z5
     G90
     ${auxOff}
@@ -366,7 +389,7 @@ function buildLoadTool(settings, toolNumber, tlsRoutine, hasUnload, currentTool)
 }
 
 function buildToolChangeProgram(settings, currentTool, toolNumber, toolOffsets = { x: 0, y: 0 }) {
-  const tlsRoutine = createToolLengthSetRoutine(settings, toolOffsets);
+  const tlsRoutine = createToolLengthSetRoutine(settings, toolOffsets, toolNumber);
   const hasUnload = currentTool !== 0;
 
   const unloadSection = buildUnloadTool(settings, currentTool, toolNumber);
@@ -408,7 +431,7 @@ function handleTLSCommand(commands, context, settings) {
   const toolOffsets = getToolOffsets(currentTool, context.tools);
 
   const tlsCommand = commands[tlsIndex];
-  const toolLengthSetRoutine = createToolLengthSetRoutine(settings, toolOffsets);
+  const toolLengthSetRoutine = createToolLengthSetRoutine(settings, toolOffsets, currentTool);
 
   const preToolChangeCmd = settings.preToolChangeGcode?.trim() || '';
   const postToolChangeCmd = settings.postToolChangeGcode?.trim() || '';
@@ -503,7 +526,7 @@ function handleHomeCommand(commands, context, settings) {
   const toolOffsets = getToolOffsets(currentTool, context.tools);
 
   const homeCommand = commands[homeIndex];
-  const tlsRoutine = createToolLengthSetRoutine(settings, toolOffsets);
+  const tlsRoutine = createToolLengthSetRoutine(settings, toolOffsets, currentTool);
 
   const preToolChangeCmd = settings.preToolChangeGcode?.trim() || '';
   const postToolChangeCmd = settings.postToolChangeGcode?.trim() || '';
@@ -606,3 +629,4 @@ function onBeforeCommand(commands, context, settings) {
   return commands;
 }
 
+export { onBeforeCommand, buildInitialConfig };

--- a/config.html
+++ b/config.html
@@ -146,6 +146,11 @@
     margin-left: auto;
   }
 
+  .rcs-form-group-vertical {
+    display: flex;
+    flex-direction: column;
+  }
+
   .rcs-select {
     padding: 8px 12px;
     padding-right: 24px;
@@ -653,6 +658,9 @@
     <button class="rcs-tab active" data-tab="basic">
       <span class="rcs-tab-label">Basic</span>
     </button>
+    <button class="rcs-tab" data-tab="probe">
+      <span class="rcs-tab-label">Probe</span>
+    </button>
     <button class="rcs-tab" data-tab="events">
       <span class="rcs-tab-label">Events</span>
     </button>
@@ -901,6 +909,43 @@
         </div>
       </div>
 
+      <!-- Probe Tab -->
+      <div class="rcs-tab-panel" id="rcs-tab-probe">
+        <div class="rcs-container">
+          <!-- Left Column -->
+          <div class="rcs-left-column">
+            <div class="rcs-pocket-group">
+              <div class="rcs-pocket-header">
+                <div class="rcs-pocket-header-left">
+                  <span class="rcs-pocket-title">Probe Settings</span>
+                </div>
+              </div>
+              <div class="rcs-toggle-row">
+                <span class="rcs-toggle-label">Enable Probe Tool</span>
+                <div class="rcs-tooltip-wrapper">
+                  <span class="rcs-tooltip-trigger" tabindex="0">?</span>
+                  <div class="rcs-tooltip-content rcs-tooltip-left">Enable probe tool (T99) in the main app.</div>
+                </div>
+                <div class="rcs-toggle-switch" id="rcs-add-probe">
+                  <div class="rcs-toggle-switch-knob"></div>
+                </div>
+              </div>
+
+              <div id="rcs-probe-gcode-fields" class="rcs-form-group-vertical" style="gap: 8px; flex: 1; display: flex; flex-direction: column;">
+                <div style="display: flex; flex-direction: column; flex: 1;">
+                  <label class="rcs-form-label" style="text-align: left;">Load Probe G-code</label>
+                  <div id="rcs-probe-load-gcode-editor" class="rcs-monaco-container"></div>
+                </div>
+                <div style="display: flex; flex-direction: column; flex: 1;">
+                  <label class="rcs-form-label" style="text-align: left;">Unload Probe G-code</label>
+                  <div id="rcs-probe-unload-gcode-editor" class="rcs-monaco-container"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- Events Tab -->
       <div class="rcs-tab-panel" id="rcs-tab-events">
         <div class="rcs-events-container">
@@ -979,6 +1024,9 @@
         tlsAuxOutput: raw.tlsAuxOutput === 'M7' || raw.tlsAuxOutput === 'M8'
           ? raw.tlsAuxOutput
           : toFiniteNumber(raw.tlsAuxOutput, -1),
+        addProbe: raw.addProbe ?? false,
+        probeLoadGcode: raw.probeLoadGcode ?? '',
+        probeUnloadGcode: raw.probeUnloadGcode ?? '',
         preToolChangeGcode: raw.preToolChangeGcode || '',
         postToolChangeGcode: raw.postToolChangeGcode || '',
         abortEventGcode: raw.abortEventGcode || ''
@@ -991,6 +1039,8 @@
     let preToolChangeEditor = null;
     let postToolChangeEditor = null;
     let abortEventEditor = null;
+    let probeLoadEditor= null;
+    let probeUnloadEditor = null;
 
     // Tab switching
     const tabs = document.querySelectorAll('.rcs-tab');
@@ -1011,6 +1061,10 @@
           if (preToolChangeEditor) preToolChangeEditor.layout();
           if (postToolChangeEditor) postToolChangeEditor.layout();
           if (abortEventEditor) abortEventEditor.layout();
+        }
+        if (targetTab === 'probe') {
+          if (probeLoadEditor) probeLoadEditor.layout();
+          if (probeUnloadEditor) probeUnloadEditor.layout();
         }
       });
     });
@@ -1087,6 +1141,22 @@
         abortEventEditor = monaco.editor.create(abortEventContainer, {
           ...monacoOptions,
           value: initialConfig.abortEventGcode || ''
+        });
+      }
+
+      const probeLoadContainer = document.getElementById('rcs-probe-load-gcode-editor');
+      if (probeLoadContainer) {
+        probeLoadEditor = monaco.editor.create(probeLoadContainer, {
+          ...monacoOptions,
+          value: initialConfig.probeLoadGcode || ''
+        });
+      }
+
+      const probeUnloadContainer = document.getElementById('rcs-probe-unload-gcode-editor');
+      if (probeUnloadContainer) {
+        probeUnloadEditor = monaco.editor.create(probeUnloadContainer, {
+          ...monacoOptions,
+          value: initialConfig.probeUnloadGcode || ''
         });
       }
 
@@ -1232,7 +1302,41 @@
         }
       }
 
+      const addProbeToggle = document.getElementById('rcs-add-probe');
+      if (addProbeToggle) {
+        if (initialConfig.addProbe) {
+          addProbeToggle.classList.add('active');
+        } else {
+          addProbeToggle.classList.remove('active');
+        }
+      }
+
       // tlsAuxOutput is set after dropdown is populated
+    };
+
+    var updateProbeGcodeState = function() {
+      var addProbeToggle = document.getElementById('rcs-add-probe');
+      var probeGcodeFields = document.getElementById('rcs-probe-gcode-fields');
+      var loadEditorContainer = document.getElementById('rcs-probe-load-gcode-editor');
+      var unloadEditorContainer = document.getElementById('rcs-probe-unload-gcode-editor');
+
+      if (!addProbeToggle || !probeGcodeFields) return;
+
+      const isEnabled = addProbeToggle && addProbeToggle.classList.contains('active');
+      
+      if (isEnabled) {
+        probeGcodeFields.classList.remove('disabled');
+        if (loadEditorContainer) loadEditorContainer.classList.remove('disabled');
+        if (unloadEditorContainer) unloadEditorContainer.classList.remove('disabled');
+        if (probeLoadEditor) probeLoadEditor.updateOptions({ readOnly: false });
+        if (probeUnloadEditor) probeUnloadEditor.updateOptions({ readOnly: false });
+      } else {
+        probeGcodeFields.classList.add('disabled');
+        if (loadEditorContainer) loadEditorContainer.classList.add('disabled');
+        if (unloadEditorContainer) unloadEditorContainer.classList.add('disabled');
+        if (probeLoadEditor) probeLoadEditor.updateOptions({ readOnly: true });
+        if (probeUnloadEditor) probeUnloadEditor.updateOptions({ readOnly: true });
+      }
     };
 
     const grabCoordinates = async (prefix) => {
@@ -1288,6 +1392,7 @@
       const waitForSpindleToggle = document.getElementById('rcs-wait-for-spindle-toggle');
       const showMacroCommandToggle = document.getElementById('rcs-show-macro-command-toggle');
       const performTlsAfterHomeToggle = document.getElementById('rcs-perform-tls-after-home-toggle');
+      const addProbeToggle = document.getElementById('rcs-add-probe');
 
       return {
         pocket1: {
@@ -1315,6 +1420,9 @@
         waitForSpindle: waitForSpindleToggle ? waitForSpindleToggle.classList.contains('active') : true,
         showMacroCommand: showMacroCommandToggle ? showMacroCommandToggle.classList.contains('active') : false,
         performTlsAfterHome: performTlsAfterHomeToggle ? performTlsAfterHomeToggle.classList.contains('active') : false,
+        addProbe: addProbeToggle ? addProbeToggle.classList.contains('active') : false,
+        probeLoadGcode: probeLoadEditor ? probeLoadEditor.getValue() : '',
+        probeUnloadGcode: probeUnloadEditor ? probeUnloadEditor.getValue() : '',
         tlsAuxOutput: (() => {
           const val = getInput('rcs-tls-aux-output').value;
           if (val === 'M7' || val === 'M8') return val;
@@ -1363,7 +1471,8 @@
                 count: payload.numberOfTools || 1,
                 source: 'com.ncsender.manualtoolchange',
                 manual: true,
-                tls: true
+                tls: true,
+                probe: payload.addProbe
               }
             })
           });
@@ -1647,6 +1756,14 @@
       });
     }
 
+    const addProbeToggle = document.getElementById('rcs-add-probe');
+    if (addProbeToggle) {
+      addProbeToggle.addEventListener('click', function() {
+        addProbeToggle.classList.toggle('active');
+        updateProbeGcodeState();
+      });
+    }
+
     window.addEventListener('message', handleServerStateUpdate);
 
     // Populate number of tools dropdown (1-98)
@@ -1661,6 +1778,7 @@
     }
 
     applyInitialSettings();
+    updateProbeGcodeState();
     updateRapidChangeState();
 
     registerButton(POCKET_PREFIX, 'rcs-pocket1-grab');

--- a/config.html
+++ b/config.html
@@ -931,6 +931,33 @@
                 </div>
               </div>
 
+              <div class="rcs-toggle-row" id="rcs-legacy-probe-row">
+                <span class="rcs-toggle-label">Use Legacy Tool Probe Method</span>
+                <div class="rcs-tooltip-wrapper">
+                  <span class="rcs-tooltip-trigger" tabindex="0">?</span>
+                  <div class="rcs-tooltip-content rcs-tooltip-left">Enable to use older Probe method when performing the TLS of the Probe. This will only use G38.2 Probing with a second slower Probe for accuracy.</div>
+                </div>
+                <div class="rcs-toggle-switch" id="rcs-legacy-probe">
+                  <div class="rcs-toggle-switch-knob"></div>
+                </div>
+              </div>
+              <div class="rcs-form-group-horizontal" id="rcs-second-seek-distance-row">
+                <label class="rcs-form-label">Second Seek Distance (mm)</label>
+                <div class="rcs-tooltip-wrapper">
+                  <span class="rcs-tooltip-trigger" tabindex="0">?</span>
+                  <div class="rcs-tooltip-content rcs-tooltip-left">Distance to pull away from TLS to perform the second slower more accurate Probe.</div>
+                </div>
+                <input type="number" class="rcs-input" id="rcs-second-seek-distance" value="1" step="0.5" min="0.5">
+              </div>
+              <div class="rcs-form-group-horizontal" id="rcs-second-seek-feedrate-row">
+                <label class="rcs-form-label">Second Seek Feedrate (mm/min)</label>
+                <div class="rcs-tooltip-wrapper">
+                  <span class="rcs-tooltip-trigger" tabindex="0">?</span>
+                  <div class="rcs-tooltip-content rcs-tooltip-left">Speed at which the tool moves downward during second probing. Use a Lower value than your initial Seek Feedrate.</div>
+                </div>
+                <input type="number" class="rcs-input" id="rcs-second-seek-feedrate" value="25" step="5" min="5">
+              </div>
+
               <div id="rcs-probe-gcode-fields" class="rcs-form-group-vertical" style="gap: 8px; flex: 1; display: flex; flex-direction: column;">
                 <div style="display: flex; flex-direction: column; flex: 1;">
                   <label class="rcs-form-label" style="text-align: left;">Load Probe G-code</label>
@@ -980,6 +1007,7 @@
 <script>
   (function() {
     const FALLBACK_PORT = __SERVER_PORT__;
+    const initialConfig = __INITIAL_CONFIG__;
     const BASE_URL = '';
     const POCKET_PREFIX = 'pocket1';
     const TOOLSETTER_PREFIX = 'toolsetter';
@@ -999,41 +1027,6 @@
         z: toFiniteNumber(coords.z)
       };
     };
-    var buildInitialConfig = function(raw) {
-      raw = raw || {};
-      return {
-        pocket1: sanitizeCoords(raw.pocket1),
-        toolSetter: sanitizeCoords(raw.toolSetter),
-        parking: sanitizeCoords(raw.parking),
-        numberOfTools: toFiniteNumber(raw.numberOfTools, 1),
-        autoSwap: raw.autoSwap === true,
-        pauseBeforeUnload: raw.pauseBeforeUnload !== false,
-        showMacroCommand: raw.showMacroCommand || false,
-        performTlsAfterHome: raw.performTlsAfterHome || false,
-        waitForSpindle: raw.waitForSpindle !== false,
-        zEngagement: toFiniteNumber(raw.zEngagement, -50),
-        zSafe: toFiniteNumber(raw.zSafe, 0),
-        zSpinOff: toFiniteNumber(raw.zSpinOff, 23),
-        zRetreat: toFiniteNumber(raw.zRetreat, 12),
-        unloadRpm: toFiniteNumber(raw.unloadRpm, 1500),
-        loadRpm: toFiniteNumber(raw.loadRpm, 1200),
-        engageFeedrate: toFiniteNumber(raw.engageFeedrate, 3500),
-        zProbeStart: toFiniteNumber(raw.zProbeStart, -10),
-        seekDistance: toFiniteNumber(raw.seekDistance, 50),
-        seekFeedrate: toFiniteNumber(raw.seekFeedrate, 100),
-        tlsAuxOutput: raw.tlsAuxOutput === 'M7' || raw.tlsAuxOutput === 'M8'
-          ? raw.tlsAuxOutput
-          : toFiniteNumber(raw.tlsAuxOutput, -1),
-        addProbe: raw.addProbe ?? false,
-        probeLoadGcode: raw.probeLoadGcode ?? '',
-        probeUnloadGcode: raw.probeUnloadGcode ?? '',
-        preToolChangeGcode: raw.preToolChangeGcode || '',
-        postToolChangeGcode: raw.postToolChangeGcode || '',
-        abortEventGcode: raw.abortEventGcode || ''
-      };
-    };
-
-    const initialConfig = buildInitialConfig(__INITIAL_CONFIG__);
 
     // Monaco editor instances
     let preToolChangeEditor = null;
@@ -1256,6 +1249,8 @@
       getInput('rcs-unload-rpm').value = initialConfig.unloadRpm || 1500;
       getInput('rcs-load-rpm').value = initialConfig.loadRpm || 1200;
       getInput('rcs-z-retreat').value = initialConfig.zRetreat || 12;
+      getInput('rcs-second-seek-distance').value = initialConfig.secondSeekDistance || 1;
+      getInput('rcs-second-seek-feedrate').value = initialConfig.secondSeekFeedrate || 25;
 
       const autoSwapToggle = document.getElementById('rcs-autoswap-toggle');
       if (autoSwapToggle) {
@@ -1311,18 +1306,34 @@
         }
       }
 
+      const legacyProbeToggle = document.getElementById('rcs-legacy-probe');
+      if (legacyProbeToggle) {
+        if (initialConfig.legacyProbe) {
+          legacyProbeToggle.classList.add('active');
+        } else {
+          legacyProbeToggle.classList.remove('active');
+        }
+      }
+
       // tlsAuxOutput is set after dropdown is populated
     };
 
     var updateProbeGcodeState = function() {
       var addProbeToggle = document.getElementById('rcs-add-probe');
+      var legacyProbeToggle = document.getElementById('rcs-legacy-probe');
+      var secondSeekDistanceRow = document.getElementById('rcs-second-seek-distance-row');
+      var secondSeekFeedrateRow = document.getElementById('rcs-second-seek-feedrate-row');
       var probeGcodeFields = document.getElementById('rcs-probe-gcode-fields');
       var loadEditorContainer = document.getElementById('rcs-probe-load-gcode-editor');
       var unloadEditorContainer = document.getElementById('rcs-probe-unload-gcode-editor');
 
+      const secondSeekDistance = getInput('rcs-second-seek-distance');
+      const secondSeekFeedrate = getInput('rcs-second-seek-feedrate');
+
       if (!addProbeToggle || !probeGcodeFields) return;
 
       const isEnabled = addProbeToggle && addProbeToggle.classList.contains('active');
+      const isLegacy = legacyProbeToggle && legacyProbeToggle.classList.contains('active');
       
       if (isEnabled) {
         probeGcodeFields.classList.remove('disabled');
@@ -1337,6 +1348,18 @@
         if (probeLoadEditor) probeLoadEditor.updateOptions({ readOnly: true });
         if (probeUnloadEditor) probeUnloadEditor.updateOptions({ readOnly: true });
       }
+
+      if (isLegacy) {
+        secondSeekDistanceRow.classList.remove('disabled');
+        secondSeekFeedrateRow.classList.remove('disabled');
+      } else {
+        secondSeekDistanceRow.classList.add('disabled');
+        secondSeekFeedrateRow.classList.add('disabled');
+      }
+
+      [secondSeekDistance, secondSeekFeedrate].forEach(el => {
+        if (el) el.disabled = !isLegacy;
+      });
     };
 
     const grabCoordinates = async (prefix) => {
@@ -1393,6 +1416,7 @@
       const showMacroCommandToggle = document.getElementById('rcs-show-macro-command-toggle');
       const performTlsAfterHomeToggle = document.getElementById('rcs-perform-tls-after-home-toggle');
       const addProbeToggle = document.getElementById('rcs-add-probe');
+      const legacyProbeToggle = document.getElementById('rcs-legacy-probe');
 
       return {
         pocket1: {
@@ -1423,6 +1447,9 @@
         addProbe: addProbeToggle ? addProbeToggle.classList.contains('active') : false,
         probeLoadGcode: probeLoadEditor ? probeLoadEditor.getValue() : '',
         probeUnloadGcode: probeUnloadEditor ? probeUnloadEditor.getValue() : '',
+        legacyProbe: legacyProbeToggle ? legacyProbeToggle.classList.contains('active') : false,
+        secondSeekDistance: parseFloat(getInput('rcs-second-seek-distance').value) || 1,
+        secondSeekFeedrate: parseFloat(getInput('rcs-second-seek-feedrate').value) || 25,
         tlsAuxOutput: (() => {
           const val = getInput('rcs-tls-aux-output').value;
           if (val === 'M7' || val === 'M8') return val;
@@ -1760,6 +1787,14 @@
     if (addProbeToggle) {
       addProbeToggle.addEventListener('click', function() {
         addProbeToggle.classList.toggle('active');
+        updateProbeGcodeState();
+      });
+    }
+
+    const legacyProbeToggle = document.getElementById('rcs-legacy-probe');
+    if (legacyProbeToggle) {
+      legacyProbeToggle.addEventListener('click', function() {
+        legacyProbeToggle.classList.toggle('active');
         updateProbeGcodeState();
       });
     }


### PR DESCRIPTION
After adding the Pull Request for adding the Probe to the Tool List, my combination of 3D Probe and Tool Length Setting do not work well with the G38.2 and G38.4 commands (Basically one NC, one NO, and when they trigger at the same time, its detected as not triggered, causing issues when running the G38.4 command)

I have added an option under the Probe Settings to Run the Probe in "Legacy" mode (can change this name if you like). This does the Older method of Probe once fast, then pull back, and Probe a second time slower, resolving these issues.